### PR TITLE
Restrict Docker publishing to push workflows

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -31,11 +31,7 @@ jobs:
     runs-on: ${{ matrix.runner }}
     steps:
       - uses: actions/checkout@v6
-      - uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
-      - name: build and push
+      - name: Build and test
         env:
           DRUPAL_VER: ${{ env.DRUPAL11 }}
           PHP_VER: ${{ matrix.php }}
@@ -44,7 +40,19 @@ jobs:
         run: |
           make
           make test
-          make push
+      - uses: docker/login-action@v3
+        if: github.event_name == 'push'
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+      - name: Push architecture image
+        if: github.event_name == 'push'
+        env:
+          DRUPAL_VER: ${{ env.DRUPAL11 }}
+          PHP_VER: ${{ matrix.php }}
+          ARCH: ${{ matrix.arch }}
+        working-directory: '11'
+        run: make push
 
   build-drupal10:
     strategy:
@@ -61,11 +69,7 @@ jobs:
     runs-on: ${{ matrix.runner }}
     steps:
       - uses: actions/checkout@v6
-      - uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
-      - name: build and push
+      - name: Build and test
         env:
           DRUPAL_VER: ${{ env.DRUPAL10 }}
           PHP_VER: ${{ matrix.php }}
@@ -74,9 +78,22 @@ jobs:
         run: |
           make
           make test
-          make push
+      - uses: docker/login-action@v3
+        if: github.event_name == 'push'
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+      - name: Push architecture image
+        if: github.event_name == 'push'
+        env:
+          DRUPAL_VER: ${{ env.DRUPAL10 }}
+          PHP_VER: ${{ matrix.php }}
+          ARCH: ${{ matrix.arch }}
+        working-directory: '10'
+        run: make push
 
   push-drupal11:
+    if: github.event_name == 'push'
     runs-on: ubuntu-latest
     needs:
       - build-drupal11
@@ -105,6 +122,7 @@ jobs:
           workdir: 11
 
   push-drupal10:
+    if: github.event_name == 'push'
     runs-on: ubuntu-latest
     needs:
       - build-drupal10


### PR DESCRIPTION
Pull-request workflows currently authenticate to Docker Hub before running checked-out repository code. This change keeps registry credentials out of pull-request jobs while preserving image publication for trusted branch and tag pushes.

## Summary

- run image builds and tests before registry authentication
- authenticate and push architecture images only for `push` events
- skip the final manifest/tag publishing job for pull requests

## Validation

- `actionlint .github/workflows/workflow.yml`
- verified every Docker secret reference and `make push` step is guarded by a push-only condition

## Follow-up

Rotate the Docker Hub token if there is evidence that an untrusted same-repository pull-request workflow previously ran with access to it.
